### PR TITLE
Added a default image width to the CMS preview

### DIFF
--- a/templates/ShareCarePreview.ss
+++ b/templates/ShareCarePreview.ss
@@ -17,6 +17,10 @@
 		max-width:240px;
 		color: #666;
 	}
+    .share-care-preview .message img {
+        width: 100%;
+		max-width: 240px;
+    }
 	.share-care-field div.message p:last-child {
 		margin: 0;
 	}


### PR DESCRIPTION
If there was a default fallback image set, that isn't a SS Image, the image would render full size. This is because of the img tag not getting a width/height set. I added some css restraints to keep the layout intact.

before:
![screen shot 2016-04-11 at 11 56 26](https://cloud.githubusercontent.com/assets/1334195/14423521/8e554ce8-ffdc-11e5-8fb1-b17043545d3f.png)

after:
![screen shot 2016-04-11 at 11 57 03](https://cloud.githubusercontent.com/assets/1334195/14423523/91ea6b0e-ffdc-11e5-9b58-63ddbde2db79.png)
