### PR TITLE
Add a try catch around the Guzzle Http request

### DIFF
--- a/src/ShareCare.php
+++ b/src/ShareCare.php
@@ -93,12 +93,16 @@ class ShareCare extends DataExtension
             $anonymousUser = new Member();
             if ($this->owner->can('View', $anonymousUser)) {
                 $client = new Client();
-                $client->request('GET', 'https://graph.facebook.com/', [
-                    'query' => [
-                        'id' => $this->owner->AbsoluteLink(),
-                        'scrape' => true,
-                    ]
-                ]);
+                try {
+                    $client->request('GET', 'https://graph.facebook.com/', [
+                        'query' => [
+                            'id' => $this->owner->AbsoluteLink(),
+                            'scrape' => true,
+                        ]
+                    ]);
+                } catch (\Exception $e) {
+                    user_error($e->getMessage(), E_USER_WARNING);
+                }
             }
         }
     }


### PR DESCRIPTION
This would throw an error on production sites so pages could not be published. The fix makes the error soft