### PR TITLE
Fix path to apple-touch-icon.png

### DIFF
--- a/src/ShareCare.php
+++ b/src/ShareCare.php
@@ -278,7 +278,7 @@ class ShareCare extends DataExtension
     public function getDefaultOGImage()
     {
         // We don't want to use the SilverStripe logo, so let's use a favicon if available.
-        return (file_exists(BASE_PATH . '/apple-touch-icon.png'))
+        return (file_exists(PUBLIC_PATH . '/apple-touch-icon.png'))
             ? Director::absoluteURL('apple-touch-icon.png', true)
             : false;
     }


### PR DESCRIPTION
The `file_exists()` check will return false for any sites using `public/`. This is BC-safe for SS4 because `PUBLIC_PATH` will fall back to `BASE_PATH` if the public directory is not being used