### PR TITLE
Rename MetaTags method to updateMetaTags

### DIFF
--- a/src/ShareCare.php
+++ b/src/ShareCare.php
@@ -252,7 +252,7 @@ class ShareCare extends Extension
     /**
      * Extension hook for including Twitter Card markup.
      */
-    public function MetaTags(&$tags)
+    public function updateMetaTags(&$tags)
     {
         if (self::config()->get('twitter_card')) {
             $tags .= $this->getOwner()->getTwitterMetaTags();


### PR DESCRIPTION
https://docs.silverstripe.org/en/6/changelogs/6.0.0/#hooks-renamed
I do not use `twitter_card`, but looks like needed for 6.x